### PR TITLE
[BUGFIX] Fix select field styling

### DIFF
--- a/Resources/Private/Styles/_Forms.scss
+++ b/Resources/Private/Styles/_Forms.scss
@@ -103,8 +103,6 @@ input[type="number"],
 
 	select {
 		@include appearance(none);
-		-o-appearance: window;
-		-moz-appearance: window;
 		background-color: transparent;
 		line-height: 18px;
 		padding: 3px 14px;

--- a/Resources/Public/Styles/Setup.css
+++ b/Resources/Public/Styles/Setup.css
@@ -319,8 +319,6 @@ input[type="number"].neos-modified,
 .select select {
   -moz-appearance: none;
   -webkit-appearance: none;
-  -o-appearance: window;
-  -moz-appearance: window;
   background-color: transparent;
   line-height: 18px;
   padding: 3px 14px;


### PR DESCRIPTION
Removes -*-appearance, because Firefox@Ubuntu 14.04 forced the select field with background-color white.