### PR TITLE
BUGFIX: Avoid open_basedir restriction on php binary check

### DIFF
--- a/Classes/TYPO3/Setup/Core/RequestHandler.php
+++ b/Classes/TYPO3/Setup/Core/RequestHandler.php
@@ -237,6 +237,7 @@ class RequestHandler extends FlowRequestHandler {
 	 * So we must check existence of this file with system tools.
 	 * 
 	 * @param string $phpBinaryPathAndFilename
+	 * @return boolean
 	 */
 	protected function phpBinaryExistsAndIsExecutableFile($phpBinaryPathAndFilename) {
         	if (DIRECTORY_SEPARATOR === '/') { 

--- a/Classes/TYPO3/Setup/Core/RequestHandler.php
+++ b/Classes/TYPO3/Setup/Core/RequestHandler.php
@@ -243,7 +243,7 @@ class RequestHandler extends FlowRequestHandler {
         	if (DIRECTORY_SEPARATOR === '/') { 
         	        $command = sprintf('test -f "%s" && test -f "%s" && test -x "%s"', $phpBinaryPathAndFilename, $phpBinaryPathAndFilename, $phpBinaryPathAndFilename);
         	} else { 
-                	$command = sprintf('IF EXISTS "%s" && IF NOT EXISTS "%s\NUL" (return 0) ELSE (return 1)', $phpBinaryPathAndFilename, $phpBinaryPathAndFilename);
+                	$command = sprintf('IF EXIST "%s" (IF NOT EXIST "%s"\* (EXIT 0) ELSE (EXIT 1)) ELSE (EXIT 1)', $phpBinaryPathAndFilename, $phpBinaryPathAndFilename);
         	}
 
 		exec($command, $outputLines, $exitCode);

--- a/Classes/TYPO3/Setup/Core/RequestHandler.php
+++ b/Classes/TYPO3/Setup/Core/RequestHandler.php
@@ -161,7 +161,7 @@ class RequestHandler extends FlowRequestHandler {
 	 */
 	protected function checkPhpBinary($phpBinaryPathAndFilename) {
 		$phpVersion = NULL;
-		if (file_exists($phpBinaryPathAndFilename) && is_file($phpBinaryPathAndFilename)) {
+		if ($this->phpBinaryExistsAndIsExecutableFile($phpBinaryPathAndFilename)) {
 			if (DIRECTORY_SEPARATOR === '/') {
 				$phpCommand = '"' . escapeshellcmd(Files::getUnixStylePath($phpBinaryPathAndFilename)) . '"';
 			} else {
@@ -228,4 +228,29 @@ class RequestHandler extends FlowRequestHandler {
 		}
 		return array(NULL, $lastCheckMessage);
 	}
+
+	/**
+	 * Checks if PHP binary file exists bypassing open_basedir violation.
+	 * 
+	 * If PHP binary is not within open_basedir path, 
+	 * it is impossible to access this binary in any other way then exec() or system().
+	 * So we must check existence of this file with system tools.
+	 * 
+	 * @param string $phpBinaryPathAndFilename
+	 */
+	protected function phpBinaryExistsAndIsExecutableFile($phpBinaryPathAndFilename) {
+        	if (DIRECTORY_SEPARATOR === '/') { 
+        	        $command = sprintf('test -f "%s" && test -f "%s" && test -x "%s"', $phpBinaryPathAndFilename, $phpBinaryPathAndFilename, $phpBinaryPathAndFilename);
+        	} else { 
+                	$command = sprintf('IF EXISTS "%s" && IF NOT EXISTS "%s\NUL" (return 0) ELSE (return 1)', $phpBinaryPathAndFilename, $phpBinaryPathAndFilename);
+        	}
+
+		exec($command, $outputLines, $exitCode);
+		if ($exitCode === 0) {
+			return true;
+		}		
+
+		return false;
+	}
+
 }


### PR DESCRIPTION
This change will bring up the compatibility for some ISPs( Webhosting Software)

When checking if `phpBinaryPathAndFilename` exists PHP returns false and logs
`PHP Warning:  file_exists(): open_basedir restriction in effect. File(/usr/local/php56/bin/php) is not within the allowed path(s)`
on the most (rather all) webhosting platforms(f.x. Plesk).

By using system commands to check file existence inside exec() this behavior can be avoided.