### PR TITLE
TASK: include invalid path into error message

### DIFF
--- a/Classes/TYPO3/Setup/Core/RequestHandler.php
+++ b/Classes/TYPO3/Setup/Core/RequestHandler.php
@@ -184,7 +184,7 @@ class RequestHandler extends FlowRequestHandler {
 			}
 		}
 		if ($phpVersion === NULL) {
-			return new Error('The specified path to your PHP binary (see Configuration/Settings.yaml) is incorrect.', 1341839376, array(), 'Environment requirements not fulfilled');
+			return new Error('The specified path to your PHP binary (see Configuration/Settings.yaml) is incorrect: not found at "%s"', 1341839376, array($phpBinaryPathAndFilename), 'Environment requirements not fulfilled');
 		} else {
 			$phpMinorVersionMatch = array_slice(explode('.', $phpVersion), 0, 2) === array_slice(explode('.', PHP_VERSION), 0, 2);
 			if ($phpMinorVersionMatch) {


### PR DESCRIPTION
Unless the local path to the PHP binary is found
the setup includes the invalid path into its error
message to help debugging.