### PR TITLE
BUGFIX: Unescape HTML output for image library selection in setup

### DIFF
--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -92,3 +92,6 @@ TYPO3:
           'TYPO3.Form:SingleSelectDropdown':
             renderingOptions:
               templatePathPattern: 'resource://TYPO3.Setup/Private/Form/{@type}.html'
+          'TYPO3.Form:StaticText':
+            renderingOptions:
+              templatePathPattern: 'resource://TYPO3.Setup/Private/Form/{@type}.html'

--- a/Resources/Private/Form/StaticText.html
+++ b/Resources/Private/Form/StaticText.html
@@ -1,0 +1,6 @@
+<f:if condition="{element.label}">
+    <h2>{element.label -> f:translate(id: 'forms.elements.{element.identifier}.label', package: element.renderingOptions.translationPackage) -> f:format.raw()}</h2>
+</f:if>
+<f:if condition="{element.properties.text}">
+    <p{f:if(condition: element.properties.elementClassAttribute, then: ' class="{element.properties.elementClassAttribute}"')}>{element.properties.text -> f:translate(id: 'forms.elements.{element.identifier}.text', package: '{element.renderingOptions.translationPackage}') -> f:format.nl2br() -> f:format.raw()}</p>
+</f:if>


### PR DESCRIPTION
On the first step of the setup the image library options have escaped quote characters. This is fixed by changing the output of the `StaticText` form element to `raw` for the setup package.
