### PR TITLE
BUGFIX: Replace relative file paths in included css

### DIFF
--- a/Classes/TYPO3/Setup/Core/MessageRenderer.php
+++ b/Classes/TYPO3/Setup/Core/MessageRenderer.php
@@ -63,6 +63,7 @@ class MessageRenderer {
 		}
 		if ($packageManager->isPackageAvailable('TYPO3.Setup')) {
 			$css .= file_get_contents($packageManager->getPackage('TYPO3.Setup')->getResourcesPath() . 'Public/Styles/Setup.css');
+			$css = str_replace('url(\'../', 'url(\'/_Resources/Static/Packages/TYPO3.Setup/', $css);
 		}
 
 		echo '<html>';


### PR DESCRIPTION
Replace relative file paths in included css with absolute ones.

That fixes the loading of the fonts in: ``Resources/Public/Styles/Setup.css``

NEOS-1502 #close