### PR TITLE
TASK: Adapt config format to Flow 3.3 request pattern definition

### DIFF
--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -19,7 +19,10 @@ TYPO3:
               keyName: 'SetupKey'
               authenticateRoles: ['TYPO3.Setup:SetupUser']
             requestPatterns:
-              controllerObjectName: 'TYPO3\Setup\Controller\.*|TYPO3\Setup\ViewHelpers\Widget\Controller\.*'
+              'TYPO3.Neos:setupControllers':
+                pattern: 'ControllerObjectName'
+                patternOptions:
+                  controllerObjectNamePattern: 'TYPO3\Setup\Controller\.*|TYPO3\Setup\ViewHelpers\Widget\Controller\.*'
             entryPoint: 'WebRedirect'
             entryPointOptions:
               uri: 'setup/login'


### PR DESCRIPTION
With Flow 3.3, the config format for defining request patterns was changed. This adapts the setup package to the new format. See here: https://github.com/neos/flow-development-collection/pull/130
