### PR TITLE
BUGFIX: Prevent Fatal Error in Setup

### DIFF
--- a/Classes/TYPO3/Setup/Core/RequestHandler.php
+++ b/Classes/TYPO3/Setup/Core/RequestHandler.php
@@ -255,4 +255,24 @@ class RequestHandler extends FlowRequestHandler {
 		return false;
 	}
 
+	/**
+	 * Note: We override this method because the base class now uses the ComponentChain to retrieve the request
+	 *
+	 * @return Request
+	 */
+	public function getHttpRequest()
+	{
+		return $this->request;
+	}
+
+	/**
+	 * Note: We override this method because the base class now uses the ComponentChain to retrieve the response
+	 *
+	 * @return Response
+	 */
+	public function getHttpResponse()
+	{
+		return $this->response;
+	}
+
 }


### PR DESCRIPTION
This is a hotfix for a regression introduced with https://github.com/neos/flow-development-collection/pull/499.

Background:
The latest `Http\RequestHandler` of Flow internally uses
the `ComponentChain` to determine the current `Request`/`Response`.

This package uses a specialized handler which doesn't rely on
the `ComponentChain` leading to a Fatal Error.