### PR TITLE
FEATURE: Support detection of hhvm in checkPhpBinary

### DIFF
--- a/Classes/TYPO3/Setup/Core/RequestHandler.php
+++ b/Classes/TYPO3/Setup/Core/RequestHandler.php
@@ -170,7 +170,7 @@ class RequestHandler extends FlowRequestHandler {
 			// If the tested binary is a CGI binary that also runs the current request the SCRIPT_FILENAME would take precedence and create an endless recursion.
 			$possibleScriptFilenameValue = getenv('SCRIPT_FILENAME');
 			putenv('SCRIPT_FILENAME');
-			exec($phpCommand . ' -v', $phpVersionString);
+			exec($phpCommand . ' -r "echo \'(\'.php_sapi_name().\') \'.PHP_VERSION;"', $phpVersionString);
 			if ($possibleScriptFilenameValue !== FALSE) {
 				putenv('SCRIPT_FILENAME=' . (string)$possibleScriptFilenameValue);
 			}

--- a/Classes/TYPO3/Setup/Core/RequestHandler.php
+++ b/Classes/TYPO3/Setup/Core/RequestHandler.php
@@ -181,7 +181,7 @@ class RequestHandler extends FlowRequestHandler
             // If the tested binary is a CGI binary that also runs the current request the SCRIPT_FILENAME would take precedence and create an endless recursion.
             $possibleScriptFilenameValue = getenv('SCRIPT_FILENAME');
             putenv('SCRIPT_FILENAME');
-            exec($phpCommand . ' -r "echo \'(\'.php_sapi_name().\') \'.PHP_VERSION;"', $phpVersionString);
+            exec($phpCommand . ' -r "echo \'(\' . php_sapi_name() . \') \' . PHP_VERSION;"', $phpVersionString);
             if ($possibleScriptFilenameValue !== false) {
                 putenv('SCRIPT_FILENAME=' . (string)$possibleScriptFilenameValue);
             }


### PR DESCRIPTION
The detection relied on the output of the command php -v, which has different outputs for
PHP and HHVM: `PHP 5.6.28-1+deb.sury.org~xenial+1 (cli)` vs. `HipHop VM 3.13.1 (rel)`.
The detection, which just splits this string, will fail for HHVM even though it is compatible to
PHP 5.6 or PHP 7.

This change updates the detection to the ouput of `echo '(' . php_sapi_name() . ') ' . PHP_VERSION;`,
which results in a better comparable output:

PHP: `(cli) 5.6.28-1+deb.sury.org~xenial+1`
HHVM: `(cli) 5.6.99-hhvm`

With those strings, version and CLI detection works the same and covers also HHVM setups.