### PR TITLE
BUGFIX: Adapt to changes in ``ConfigurationManager``

### DIFF
--- a/Classes/Step/DatabaseStep.php
+++ b/Classes/Step/DatabaseStep.php
@@ -110,7 +110,7 @@ class DatabaseStep extends \Neos\Setup\Step\AbstractStep
         $this->distributionSettings = Arrays::setValueByPath($this->distributionSettings, 'Neos.Flow.persistence.backendOptions.host', $formValues['host']);
         $this->configurationSource->save(FLOW_PATH_CONFIGURATION . ConfigurationManager::CONFIGURATION_TYPE_SETTINGS, $this->distributionSettings);
 
-        $this->configurationManager->flushConfigurationCache();
+        $this->configurationManager->refreshConfiguration();
 
         $settings = $this->configurationManager->getConfiguration(ConfigurationManager::CONFIGURATION_TYPE_SETTINGS, 'Neos.Flow');
         $connectionSettings = $settings['persistence']['backendOptions'];


### PR DESCRIPTION
Some internals of the Flow ``ConfigurationManager`` changed,
making ``clearConfigurationCache`` the wrong method to call
in the setup, which could lead to broken configuration.