### PR TITLE
BUGFIX: deleted deprecated f:base viewhelper from setup layout

### DIFF
--- a/Resources/Private/Layouts/Default.html
+++ b/Resources/Private/Layouts/Default.html
@@ -2,7 +2,6 @@
 <html lang="en">
 	<head>
 		<meta charset="utf-8">
-		<f:base/>
 		<title>{settings.view.title}</title>
 		<link rel="stylesheet" href="{f:uri.resource(path: '3/css/bootstrap.min.css', package: 'Neos.Twitter.Bootstrap')}" />
 		<link rel="stylesheet" href="{f:uri.resource(path: 'Styles/Setup.css')}" />


### PR DESCRIPTION
Setup in neos-development-distribution did not work because f:base could not be found.