### PR TITLE
TASK: Add check for utf8mb4 support for MySQL platforms

### DIFF
--- a/Classes/ViewHelpers/Widget/Controller/DatabaseSelectorController.php
+++ b/Classes/ViewHelpers/Widget/Controller/DatabaseSelectorController.php
@@ -84,6 +84,7 @@ class DatabaseSelectorController extends \Neos\FluidAdaptor\Core\Widget\Abstract
         $this->response->setHeader('Content-Type', 'application/json');
         $connectionSettings = $this->buildConnectionSettingsArray($driver, $user, $password, $host);
         $connectionSettings['dbname'] = $databaseName;
+        $result = [];
         try {
             $connection = $this->getConnectionAndConnect($connectionSettings);
             $databasePlatform = $connection->getDatabasePlatform();
@@ -94,13 +95,13 @@ class DatabaseSelectorController extends \Neos\FluidAdaptor\Core\Widget\Abstract
                 $queryResult = $connection->executeQuery('SELECT pg_encoding_to_char(encoding) FROM pg_database WHERE datname = ?', [$databaseName])->fetch();
                 $databaseCharacterSet = strtolower($queryResult['pg_encoding_to_char']);
             } else {
-                $result = ['level' => 'error', 'message' => sprintf('Only MySQL/MariaDB and PostgreSQL are supported, the selected database is "%s".', $databasePlatform->getName())];
+                $result[] = ['level' => 'error', 'message' => sprintf('Only MySQL/MariaDB and PostgreSQL are supported, the selected database is "%s".', $databasePlatform->getName())];
             }
             if (isset($databaseCharacterSet)) {
                 if ($databaseCharacterSet === 'utf8mb4') {
-                    $result = ['level' => 'notice', 'message' => 'The selected database\'s character set is set to "utf8mb4" which is the recommended setting.'];
+                    $result[] = ['level' => 'notice', 'message' => 'The selected database\'s character set is set to "utf8mb4" which is the recommended setting.'];
                 } else {
-                    $result = [
+                    $result[] = [
                         'level' => 'warning',
                         'message' => sprintf('The selected database\'s character set is "%s", however changing it to "utf8mb4" is urgently recommended. This setup tool won\'t do this for you.', $databaseCharacterSet)
                     ];

--- a/Resources/Private/Templates/ViewHelpers/Widget/DatabaseSelector/Index.html
+++ b/Resources/Private/Templates/ViewHelpers/Widget/DatabaseSelector/Index.html
@@ -60,30 +60,34 @@
 					},
 					dataType: 'json',
 					cache: false
-				}).done(function(result) {
+				}).done(function(results) {
 					metadataStatusContainer.removeClass('loading');
-					var alertClassName,
-						iconClassName;
-					switch (result.level) {
-						case 'ok':
-							metadataStatusContainer.addClass('db-success');
-							alertClassName = 'success';
-							iconClassName = 'ok';
-							break;
-						case 'notice':
-							alertClassName = 'info';
-							iconClassName = 'info-sign';
-							break;
-						case 'warning':
-							alertClassName = 'warning';
-							iconClassName = 'warning-sign';
-							break;
-						case 'error':
-							metadataStatusContainer.addClass('error');
-							alertClassName = 'error';
-							iconClassName = 'ban-circle';
-					}
-					metadataStatusContainer.html('<div class="alert alert-' + alertClassName + '"><span class="glyphicon glyphicon-' + iconClassName + '"></span>' + result.message + '</div>');
+					var messageContainerContent = '';
+					results.forEach(function(result) {
+						var alertClassName,
+							iconClassName;
+						switch (result.level) {
+							case 'ok':
+								metadataStatusContainer.addClass('db-success');
+								alertClassName = 'success';
+								iconClassName = 'ok';
+								break;
+							case 'notice':
+								alertClassName = 'info';
+								iconClassName = 'info-sign';
+								break;
+							case 'warning':
+								alertClassName = 'warning';
+								iconClassName = 'warning-sign';
+								break;
+							case 'error':
+								metadataStatusContainer.addClass('error');
+								alertClassName = 'error';
+								iconClassName = 'ban-circle';
+						}
+						messageContainerContent += '<div class="alert alert-' + alertClassName + '"><span class="glyphicon glyphicon-' + iconClassName + '"></span>' + result.message + '</div>';
+					});
+					metadataStatusContainer.html(messageContainerContent);
 				}).error(function() {
 					metadataStatusContainer.removeClass('loading').addClass('error').text('Unexpected error');
 				});


### PR DESCRIPTION
Check if MySQL based platform fulfills minimum requirements for utf8mb4 support, by comparing the version string.

In case of a false positive, it's still possible to resume setup.