### PR TITLE
BUGFIX: Fix setup with postgres

### DIFF
--- a/Classes/Step/DatabaseStep.php
+++ b/Classes/Step/DatabaseStep.php
@@ -108,6 +108,10 @@ class DatabaseStep extends \Neos\Setup\Step\AbstractStep
         $this->distributionSettings = Arrays::setValueByPath($this->distributionSettings, 'Neos.Flow.persistence.backendOptions.user', $formValues['user']);
         $this->distributionSettings = Arrays::setValueByPath($this->distributionSettings, 'Neos.Flow.persistence.backendOptions.password', $formValues['password']);
         $this->distributionSettings = Arrays::setValueByPath($this->distributionSettings, 'Neos.Flow.persistence.backendOptions.host', $formValues['host']);
+        // Postgres natively supports multibyte-UTF8. It does not know utf8mb4, which is the default now
+        if ($formValues['driver'] === 'pdo_pgsql') {
+            $this->distributionSettings = Arrays::setValueByPath($this->distributionSettings, 'Neos.Flow.persistence.backendOptions.charset', 'utf8');
+        }
         $this->configurationSource->save(FLOW_PATH_CONFIGURATION . ConfigurationManager::CONFIGURATION_TYPE_SETTINGS, $this->distributionSettings);
 
         $this->configurationManager->refreshConfiguration();

--- a/Classes/ViewHelpers/Widget/Controller/DatabaseSelectorController.php
+++ b/Classes/ViewHelpers/Widget/Controller/DatabaseSelectorController.php
@@ -146,6 +146,8 @@ class DatabaseSelectorController extends \Neos\FluidAdaptor\Core\Widget\Abstract
         $connectionSettings['host'] = $host;
         if ($connectionSettings['driver'] === 'pdo_pgsql') {
             $connectionSettings['dbname'] = 'template1';
+            // Postgres natively supports multibyte-UTF8. It does not know utf8mb4
+            $connectionSettings['charset'] = 'utf8';
 
             return $connectionSettings;
         } else {

--- a/Classes/ViewHelpers/Widget/Controller/DatabaseSelectorController.php
+++ b/Classes/ViewHelpers/Widget/Controller/DatabaseSelectorController.php
@@ -92,8 +92,6 @@ class DatabaseSelectorController extends \Neos\FluidAdaptor\Core\Widget\Abstract
             $connection = $this->getConnectionAndConnect($connectionSettings);
             $databasePlatform = $connection->getDatabasePlatform();
             if ($databasePlatform instanceof MySqlPlatform) {
-                $queryResult = $connection->executeQuery('SHOW VARIABLES LIKE \'character_set_database\'')->fetch();
-                $databaseCharacterSet = strtolower($queryResult['Value']);
                 $databaseVersionQueryResult = $connection->executeQuery('SELECT VERSION()')->fetch();
                 $databaseVersion = isset($databaseVersionQueryResult['VERSION()']) ? $databaseVersionQueryResult['VERSION()'] : null;
                 if (isset($databaseVersion) && $this->databaseSupportsUtf8Mb4($databaseVersion) === false) {
@@ -102,21 +100,34 @@ class DatabaseSelectorController extends \Neos\FluidAdaptor\Core\Widget\Abstract
                         'message' => sprintf('The minimum required version for MySQL is "%s" or "%s" for MariaDB.', self::MINIMUM_MYSQL_VERSION, self::MINIMUM_MARIA_DB_VERSION)
                     ];
                 }
+
+                $charsetQueryResult = $connection->executeQuery('SHOW VARIABLES LIKE \'character_set_database\'')->fetch();
+                $databaseCharacterSet = strtolower($charsetQueryResult['Value']);
+                if (isset($databaseCharacterSet)) {
+                    if ($databaseCharacterSet === 'utf8mb4') {
+                        $result[] = ['level' => 'notice', 'message' => 'The selected database\'s character set is set to "utf8mb4" which is the recommended setting for MySQL/MariaDB databases.'];
+                    } else {
+                        $result[] = [
+                            'level' => 'warning',
+                            'message' => sprintf('The selected database\'s character set is "%s", however changing it to "utf8mb4" is urgently recommended. This setup tool won\'t do this for you.', $databaseCharacterSet)
+                        ];
+                    }
+                }
             } elseif ($databasePlatform instanceof PostgreSqlPlatform) {
-                $queryResult = $connection->executeQuery('SELECT pg_encoding_to_char(encoding) FROM pg_database WHERE datname = ?', [$databaseName])->fetch();
-                $databaseCharacterSet = strtolower($queryResult['pg_encoding_to_char']);
+                $charsetQueryResult = $connection->executeQuery('SELECT pg_encoding_to_char(encoding) FROM pg_database WHERE datname = ?', [$databaseName])->fetch();
+                $databaseCharacterSet = strtolower($charsetQueryResult['pg_encoding_to_char']);
+                if (isset($databaseCharacterSet)) {
+                    if ($databaseCharacterSet === 'utf8') {
+                        $result[] = ['level' => 'notice', 'message' => 'The selected database\'s character set is set to "utf8" which is the recommended setting for PostgreSQL databases.'];
+                    } else {
+                        $result[] = [
+                            'level' => 'warning',
+                            'message' => sprintf('The selected database\'s character set is "%s", however changing it to "utf8" is urgently recommended. This setup tool won\'t do this for you.', $databaseCharacterSet)
+                        ];
+                    }
+                }
             } else {
                 $result[] = ['level' => 'error', 'message' => sprintf('Only MySQL/MariaDB and PostgreSQL are supported, the selected database is "%s".', $databasePlatform->getName())];
-            }
-            if (isset($databaseCharacterSet)) {
-                if ($databaseCharacterSet === 'utf8mb4') {
-                    $result[] = ['level' => 'notice', 'message' => 'The selected database\'s character set is set to "utf8mb4" which is the recommended setting.'];
-                } else {
-                    $result[] = [
-                        'level' => 'warning',
-                        'message' => sprintf('The selected database\'s character set is "%s", however changing it to "utf8mb4" is urgently recommended. This setup tool won\'t do this for you.', $databaseCharacterSet)
-                    ];
-                }
             }
         } catch (\PDOException $exception) {
             $result = ['level' => 'error', 'message' => $exception->getMessage(), 'errorCode' => $exception->getCode()];


### PR DESCRIPTION
Since postgres does not know utf8mb4, the setup fails now when using a postgres DB. We need to manually override the charset for postgres to work.