### PR TITLE
TASK: Use PackageManager, not PackageManagerInterface

### DIFF
--- a/Classes/Core/ConfigureRoutingComponent.php
+++ b/Classes/Core/ConfigureRoutingComponent.php
@@ -17,7 +17,7 @@ use Neos\Flow\Http\Component\ComponentContext;
 use Neos\Flow\Http\Component\ComponentInterface;
 use Neos\Flow\Mvc\Routing\Router;
 use Neos\Flow\ObjectManagement\ObjectManagerInterface;
-use Neos\Flow\Package\PackageManagerInterface;
+use Neos\Flow\Package\PackageManager;
 
 /**
  * Configure routing HTTP component for Neos setup
@@ -44,7 +44,7 @@ class ConfigureRoutingComponent implements ComponentInterface
 
     /**
      * @Flow\Inject
-     * @var PackageManagerInterface
+     * @var PackageManager
      */
     protected $packageManager;
 

--- a/Classes/Core/MessageRenderer.php
+++ b/Classes/Core/MessageRenderer.php
@@ -13,6 +13,7 @@ namespace Neos\Setup\Core;
 
 use Neos\Flow\Annotations as Flow;
 use Neos\Error\Messages\Message;
+use Neos\Flow\Package\PackageManager;
 
 /**
  * Rendering class for displaying messages before the Flow proxy classes are built.
@@ -55,8 +56,8 @@ class MessageRenderer
             throw new \InvalidArgumentException('No messages given for rendering', 1416914970);
         }
 
-        /** @var \Neos\Flow\Package\PackageManagerInterface $packageManager */
-        $packageManager = $this->bootstrap->getEarlyInstance(\Neos\Flow\Package\PackageManagerInterface::class);
+        /** @var PackageManager $packageManager */
+        $packageManager = $this->bootstrap->getEarlyInstance(PackageManager::class);
 
         $css = '';
         if ($packageManager->isPackageAvailable('Neos.Twitter.Bootstrap')) {


### PR DESCRIPTION
The PackageManagerInterface is deprecated and will be removed with
Flow 6.0.