### PR TITLE
BUGFIX: add recursive directory creation in setup db command

### DIFF
--- a/Classes/Command/SetupCommandController.php
+++ b/Classes/Command/SetupCommandController.php
@@ -20,11 +20,11 @@ use Neos\Flow\Core\Bootstrap;
 use Neos\Setup\Domain\CliEnvironment;
 use Neos\Setup\Domain\HealthcheckEnvironment;
 use Neos\Setup\Infrastructure\HealthChecker;
-use Neos\Setup\RequestHandler\SetupCliRequestHandler;
 use Neos\Utility\Arrays;
 use Neos\Setup\Exception as SetupException;
 use Neos\Setup\Infrastructure\Database\DatabaseConnectionService;
 use Symfony\Component\Yaml\Yaml;
+use Neos\Utility\Files;
 
 class SetupCommandController extends CommandController
 {
@@ -185,6 +185,7 @@ class SetupCommandController extends CommandController
             $previousSettings = [];
         }
         $newSettings = Arrays::setValueByPath($previousSettings, $path, $settings);
+        Files::createDirectoryRecursively(dirname($filename));
         file_put_contents($filename, YAML::dump($newSettings, 10, 2));
         return YAML::dump(Arrays::setValueByPath([], $path, $settings), 10, 2);
     }


### PR DESCRIPTION
Current behavior:
If an custom flow context like `Development/Docker` is configured before configuring the database, then the db config file can not be written.

Expected behavior: 
Need subcontext folders are create and the db conifg file ist written correctly.